### PR TITLE
Add admin panel enhancements

### DIFF
--- a/src/app/admin/category-groups/page.js
+++ b/src/app/admin/category-groups/page.js
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function AdminCategoryGroupsPage() {
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [form, setForm] = useState({ name: '' });
+  const [editingId, setEditingId] = useState(null);
+
+  useEffect(() => {
+    fetchGroups();
+  }, []);
+
+  async function fetchGroups() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/category-groups');
+      const data = await res.json();
+      if (res.ok) {
+        setGroups(data.groups);
+      } else {
+        setError(data.error || 'Failed to fetch groups');
+      }
+    } catch (e) {
+      setError('Failed to fetch groups');
+    }
+    setLoading(false);
+  }
+
+  async function handleDelete(id) {
+    if (!window.confirm('Delete this group?')) return;
+    const res = await fetch('/api/admin/category-groups', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    });
+    if (res.ok) {
+      setGroups(groups.filter(g => g.id !== id));
+    } else {
+      alert('Failed to delete group');
+    }
+  }
+
+  function handleEdit(group) {
+    setForm({ name: group.name });
+    setEditingId(group.id);
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const method = editingId ? 'PATCH' : 'POST';
+    const body = editingId ? { id: editingId, ...form } : form;
+    const res = await fetch('/api/admin/category-groups', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (editingId) {
+        setGroups(groups.map(g => g.id === editingId ? data.group : g));
+        setEditingId(null);
+      } else {
+        setGroups([...groups, data.group]);
+      }
+      setForm({ name: '' });
+    } else {
+      alert('Failed to save group');
+    }
+  }
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-600">{error}</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Manage Category Groups</h1>
+      <form onSubmit={handleSubmit} className="mb-4 space-x-2">
+        <input
+          type="text"
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+          className="border px-2 py-1"
+          required
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-1 rounded">
+          {editingId ? 'Update' : 'Add'}
+        </button>
+        {editingId && (
+          <button type="button" onClick={() => { setEditingId(null); setForm({ name: '' }); }} className="ml-2 px-2 py-1 border rounded">Cancel</button>
+        )}
+      </form>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-200">
+            <th className="p-2 border">Name</th>
+            <th className="p-2 border">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map(group => (
+            <tr key={group.id} className="border-b">
+              <td className="p-2 border">{group.name}</td>
+              <td className="p-2 border space-x-2">
+                <button onClick={() => handleEdit(group)} className="bg-yellow-500 text-white px-2 py-1 rounded">Edit</button>
+                <button onClick={() => handleDelete(group.id)} className="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/admin/layout.js
+++ b/src/app/admin/layout.js
@@ -59,22 +59,41 @@ export default async function AdminLayout({ children }) {
               </svg>
               Products
             </Link>
-            <Link 
-              href="/admin/orders" 
+            <Link
+              href="/admin/orders"
               className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
             >
               <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
               </svg>
               Orders
-            </Link>            <Link 
-              href="/admin/categories" 
+            </Link>
+            <Link
+              href="/admin/categories"
               className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
             >
               <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
               </svg>
               Categories
+            </Link>
+            <Link
+              href="/admin/category-groups"
+              className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
+            >
+              <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+              Category Groups
+            </Link>
+            <Link
+              href="/admin/messages"
+              className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
+            >
+              <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+              </svg>
+              Messages
             </Link>
           </nav>
         </div>

--- a/src/app/admin/messages/page.js
+++ b/src/app/admin/messages/page.js
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function AdminMessagesPage() {
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [reply, setReply] = useState({});
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchMessages();
+  }, []);
+
+  async function fetchMessages() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/messages');
+      const data = await res.json();
+      if (res.ok) {
+        setMessages(data.messages);
+      } else {
+        setError(data.error || 'Failed to fetch messages');
+      }
+    } catch (e) {
+      setError('Failed to fetch messages');
+    }
+    setLoading(false);
+  }
+
+  async function sendReply(id) {
+    const res = await fetch('/api/admin/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, reply: reply[id] })
+    });
+    if (res.ok) {
+      setReply({ ...reply, [id]: '' });
+      fetchMessages();
+    } else {
+      alert('Failed to send reply');
+    }
+  }
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-600">{error}</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Messages</h1>
+      <div className="space-y-4">
+        {messages.map(m => (
+          <div key={m.id} className="border p-4 rounded bg-white space-y-2">
+            <div className="flex justify-between">
+              <div>
+                <p className="font-semibold">{m.subject}</p>
+                <p className="text-sm text-gray-500">From: {m.user.name} ({m.user.email})</p>
+              </div>
+              <span className="text-xs px-2 py-1 rounded bg-gray-100">{m.status}</span>
+            </div>
+            <p className="whitespace-pre-wrap">{m.content}</p>
+            <textarea
+              className="w-full border p-2 text-sm"
+              rows={3}
+              placeholder="Type reply..."
+              value={reply[m.id] || ''}
+              onChange={e => setReply({ ...reply, [m.id]: e.target.value })}
+            />
+            <button
+              onClick={() => sendReply(m.id)}
+              className="bg-blue-600 text-white px-3 py-1 rounded"
+            >
+              Send Reply
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/category-groups/route.js
+++ b/src/app/api/admin/category-groups/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import prisma from '@/lib/prisma';
+
+async function ensureAdmin() {
+  const { userId } = auth();
+  if (!userId) return { status: 401 };
+  const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
+  if (!admin || admin.role !== 'admin') return { status: 403 };
+  return { status: 200 };
+}
+
+export async function GET() {
+  const check = await ensureAdmin();
+  if (check.status !== 200) return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+  const groups = await prisma.categoryGroup.findMany();
+  return NextResponse.json({ groups });
+}
+
+export async function POST(request) {
+  const check = await ensureAdmin();
+  if (check.status !== 200) return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+  const data = await request.json();
+  const group = await prisma.categoryGroup.create({ data });
+  return NextResponse.json({ group });
+}
+
+export async function PATCH(request) {
+  const check = await ensureAdmin();
+  if (check.status !== 200) return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+  const { id, ...data } = await request.json();
+  const group = await prisma.categoryGroup.update({ where: { id }, data });
+  return NextResponse.json({ group });
+}
+
+export async function DELETE(request) {
+  const check = await ensureAdmin();
+  if (check.status !== 200) return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+  const { id } = await request.json();
+  await prisma.categoryGroup.delete({ where: { id } });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/messages/route.js
+++ b/src/app/api/admin/messages/route.js
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import prisma from '@/lib/prisma';
+import { sendEmail } from '@/lib/email';
+
+async function ensureAdmin() {
+  const { userId } = auth();
+  if (!userId) return { status: 401 };
+  const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
+  if (!admin || admin.role !== 'admin') return { status: 403 };
+  return { status: 200 };
+}
+
+export async function GET() {
+  const check = await ensureAdmin();
+  if (check.status !== 200) return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+  const messages = await prisma.message.findMany({
+    include: {
+      user: { select: { name: true, email: true } },
+      product: { select: { id: true, name: true } }
+    },
+    orderBy: { createdAt: 'desc' }
+  });
+  return NextResponse.json({ messages });
+}
+
+export async function POST(request) {
+  const check = await ensureAdmin();
+  if (check.status !== 200) return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+  const { id, reply } = await request.json();
+  const message = await prisma.message.findUnique({
+    where: { id },
+    include: { user: true }
+  });
+  if (!message) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (reply) {
+    try {
+      await sendEmail({
+        to: message.user.email,
+        subject: `Re: ${message.subject}`,
+        text: reply
+      });
+      await prisma.message.update({ where: { id }, data: { status: 'answered' } });
+    } catch (e) {
+      return NextResponse.json({ error: 'Failed to send reply' }, { status: 500 });
+    }
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/products/route.js
+++ b/src/app/api/admin/products/route.js
@@ -19,7 +19,18 @@ export async function POST(request) {
   const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
   if (!admin || admin.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const data = await request.json();
-  const product = await prisma.product.create({ data });
+  const product = await prisma.product.create({
+    data: {
+      name: data.name,
+      price: data.price,
+      stock: data.stock,
+      photoUrl: data.photoUrl,
+      categories: {
+        connect: data.categoryId ? [{ id: data.categoryId }] : [],
+      },
+    },
+    include: { categories: true },
+  });
   return NextResponse.json({ product });
 }
 
@@ -30,7 +41,19 @@ export async function PATCH(request) {
   const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
   if (!admin || admin.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const { id, ...data } = await request.json();
-  const product = await prisma.product.update({ where: { id }, data });
+  const product = await prisma.product.update({
+    where: { id },
+    data: {
+      name: data.name,
+      price: data.price,
+      stock: data.stock,
+      photoUrl: data.photoUrl,
+      categories: {
+        set: data.categoryId ? [{ id: data.categoryId }] : [],
+      },
+    },
+    include: { categories: true },
+  });
   return NextResponse.json({ product });
 }
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -8,6 +8,7 @@ export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { user, isSignedIn } = useUser();
   const { signOut } = useClerk();
+  const isAdmin = isSignedIn && user?.publicMetadata?.role === 'admin';
 
   const handleSignOut = () => {
     signOut();
@@ -47,7 +48,7 @@ export default function Navbar() {
                 <Link href="/profile" className="hover:text-gray-300">
                   Profile
                 </Link>
-                {isSignedIn && (
+                {isAdmin && (
                   <Link href="/admin" className="text-red-400 hover:text-red-300">
                     Admin Panel
                   </Link>
@@ -171,6 +172,14 @@ export default function Navbar() {
                   >
                     Profile
                   </Link>
+                  {isAdmin && (
+                    <Link
+                      href="/admin"
+                      className="block py-2 text-gray-700 hover:text-black"
+                    >
+                      Admin Panel
+                    </Link>
+                  )}
                   <button
                     onClick={handleSignOut}
                     className="block w-full text-left py-2 text-gray-700 hover:text-black"


### PR DESCRIPTION
## Summary
- add category group admin CRUD pages and API endpoints
- add admin messages API and UI for replying to user messages
- enhance product admin page with image URL and category selection
- show admin panel link only for admin users
- add category group and messages sections in admin sidebar

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5cae5c608329ab20cc3373e056d4