### PR TITLE
Add pages to Tailwind content

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],


### PR DESCRIPTION
## Summary
- configure Tailwind to scan files in the `pages/` directory

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6a45bfd88329a5f979c30857599b