### PR TITLE
Add admin settings page

### DIFF
--- a/prisma/migrations/20250614083500_add_setting_model/migration.sql
+++ b/prisma/migrations/20250614083500_add_setting_model/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "Setting" (
+    "id" INTEGER NOT NULL PRIMARY KEY,
+    "siteName" TEXT NOT NULL,
+    "siteDescription" TEXT,
+    "contactEmail" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,3 +90,12 @@ model Message {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model Setting {
+  id             Int      @id @default(1)
+  siteName       String
+  siteDescription String?
+  contactEmail   String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}

--- a/src/app/admin/layout.js
+++ b/src/app/admin/layout.js
@@ -113,6 +113,15 @@ export default async function AdminLayout({ children }) {
               </svg>
               Messages
             </Link>
+            <Link
+              href="/admin/settings"
+              className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
+            >
+              <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0a1.724 1.724 0 002.561 1.009c.852-.49 1.97.43 1.48 1.28a1.724 1.724 0 001.009 2.561c.921.3.921 1.603 0 1.902a1.724 1.724 0 00-1.009 2.561c.49.852-.43 1.97-1.28 1.48a1.724 1.724 0 00-2.561 1.009c-.3.921-1.603.921-1.902 0a1.724 1.724 0 00-2.561-1.009c-.852.49-1.97-.43-1.48-1.28a1.724 1.724 0 00-1.009-2.561c-.921-.3-.921-1.603 0-1.902a1.724 1.724 0 001.009-2.561c-.49-.852.43-1.97 1.28-1.48a1.724 1.724 0 002.561-1.009z" />
+              </svg>
+              Settings
+            </Link>
           </nav>
         </div>
       </aside><main className="flex-1 p-8">

--- a/src/app/admin/settings/page.js
+++ b/src/app/admin/settings/page.js
@@ -1,0 +1,96 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+
+export default function AdminSettingsPage() {
+  const [form, setForm] = useState({ siteName: '', siteDescription: '', contactEmail: '' });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [message, setMessage] = useState(null);
+
+  useEffect(() => {
+    async function fetchSettings() {
+      setLoading(true);
+      try {
+        const res = await fetch('/api/admin/settings');
+        const data = await res.json();
+        if (res.ok) {
+          setForm({
+            siteName: data.setting.siteName || '',
+            siteDescription: data.setting.siteDescription || '',
+            contactEmail: data.setting.contactEmail || '',
+          });
+        } else {
+          setError(data.error || 'Failed to load settings');
+        }
+      } catch (e) {
+        setError('Failed to load settings');
+      }
+      setLoading(false);
+    }
+    fetchSettings();
+  }, []);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setMessage(null);
+    const res = await fetch('/api/admin/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setForm({
+        siteName: data.setting.siteName || '',
+        siteDescription: data.setting.siteDescription || '',
+        contactEmail: data.setting.contactEmail || '',
+      });
+      setMessage('Settings updated');
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || 'Failed to update settings');
+    }
+  }
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-600">{error}</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Site Settings</h1>
+      {message && <div className="text-green-600 mb-2">{message}</div>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Site Name</label>
+          <input
+            type="text"
+            value={form.siteName}
+            onChange={e => setForm({ ...form, siteName: e.target.value })}
+            className="border px-2 py-1 w-full"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Site Description</label>
+          <textarea
+            value={form.siteDescription}
+            onChange={e => setForm({ ...form, siteDescription: e.target.value })}
+            className="border px-2 py-1 w-full"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Contact Email</label>
+          <input
+            type="email"
+            value={form.contactEmail}
+            onChange={e => setForm({ ...form, contactEmail: e.target.value })}
+            className="border px-2 py-1 w-full"
+          />
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Save
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/api/admin/settings/route.js
+++ b/src/app/api/admin/settings/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import prisma from '@/lib/prisma';
+
+export async function GET() {
+  const { userId } = auth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
+  if (!admin || admin.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  let setting = await prisma.setting.findFirst();
+  if (!setting) {
+    setting = await prisma.setting.create({ data: { siteName: 'My Site' } });
+  }
+  return NextResponse.json({ setting });
+}
+
+export async function PATCH(request) {
+  const { userId } = auth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
+  if (!admin || admin.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const data = await request.json();
+  let setting = await prisma.setting.findFirst();
+  if (!setting) {
+    setting = await prisma.setting.create({ data });
+  } else {
+    setting = await prisma.setting.update({ where: { id: setting.id }, data });
+  }
+  return NextResponse.json({ setting });
+}


### PR DESCRIPTION
## Summary
- create `Setting` model in Prisma schema
- add migration for `Setting` table
- provide API endpoints for admin settings
- implement admin settings page
- link new page in admin layout

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d32ca866c8329a36b7653390efe91