### PR TITLE
Add admin analytics page

### DIFF
--- a/src/app/admin/analytics/page.js
+++ b/src/app/admin/analytics/page.js
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+export default function AnalyticsPage() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await fetch('/api/admin/analytics');
+        if (!res.ok) throw new Error('Failed to load analytics');
+        const json = await res.json();
+        setData(json.topProducts || []);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 bg-red-50 border-l-4 border-red-500 text-red-700">
+        <p className="font-medium">Error loading analytics</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Top Products by Revenue</h1>
+      <ResponsiveContainer width="100%" height={400}>
+        <BarChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip formatter={(value) => `$${value.toLocaleString()}`} />
+          <Bar dataKey="revenue" fill="#8884d8" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/app/admin/layout.js
+++ b/src/app/admin/layout.js
@@ -105,6 +105,15 @@ export default async function AdminLayout({ children }) {
               Category Groups
             </Link>
             <Link
+              href="/admin/analytics"
+              className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
+            >
+              <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 19V6m4 13V4m4 15v-7M7 19v-4M3 19v-2" />
+              </svg>
+              Analytics
+            </Link>
+            <Link
               href="/admin/messages"
               className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg group"
             >

--- a/src/app/api/admin/analytics/route.js
+++ b/src/app/api/admin/analytics/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import prisma from '@/lib/prisma';
+
+async function ensureAdmin() {
+  const { userId } = auth();
+  if (!userId) return { status: 401 };
+  const admin = await prisma.user.findUnique({ where: { clerkId: userId } });
+  if (!admin || admin.role !== 'admin') return { status: 403 };
+  return { status: 200 };
+}
+
+export async function GET() {
+  const check = await ensureAdmin();
+  if (check.status !== 200)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: check.status });
+
+  const items = await prisma.orderItem.findMany({
+    where: { order: { status: 'completed' } },
+    include: { product: { select: { name: true } } }
+  });
+
+  const stats = {};
+  for (const item of items) {
+    if (!stats[item.productId]) {
+      stats[item.productId] = { name: item.product.name, revenue: 0, quantity: 0 };
+    }
+    stats[item.productId].revenue += item.price * item.quantity;
+    stats[item.productId].quantity += item.quantity;
+  }
+
+  const topProducts = Object.values(stats)
+    .sort((a, b) => b.revenue - a.revenue)
+    .slice(0, 5);
+
+  return NextResponse.json({ topProducts });
+}


### PR DESCRIPTION
## Summary
- create analytics API for top products
- add admin analytics page using charts
- link analytics page in admin layout

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d32ca866c8329a36b7653390efe91