### PR TITLE
Fix admin session fetch credentials

### DIFF
--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -14,9 +14,9 @@ export default function AdminDashboard() {
     async function fetchData() {
       try {
         const [uRes, pRes, cRes] = await Promise.all([
-          fetch('/api/admin/users'),
-          fetch('/api/products'),
-          fetch('/api/categories'),
+          fetch('/api/admin/users', { credentials: 'include' }),
+          fetch('/api/products', { credentials: 'include' }),
+          fetch('/api/categories', { credentials: 'include' }),
         ]);
 
         if (uRes.status === 401 || pRes.status === 401 || cRes.status === 401) {


### PR DESCRIPTION
## Summary
- include `credentials: 'include'` in admin dashboard requests so Clerk session cookies are sent

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8cece24c8329a117f3a2655ca08e