### PR TITLE
Add admin dashboard button

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -47,6 +47,9 @@ export default function Navbar() {
                 <Link href="/profile" className="hover:text-gray-300">
                   Profile
                 </Link>
+                <Link href="/admin" className="hover:text-gray-300">
+                  Admin Dashboard
+                </Link>
                 <button
                   onClick={handleSignOut}
                   className="hover:text-gray-300 cursor-pointer"
@@ -166,6 +169,12 @@ export default function Navbar() {
                     className="block py-2 text-gray-700 hover:text-black"
                   >
                     Profile
+                  </Link>
+                  <Link
+                    href="/admin"
+                    className="block py-2 text-gray-700 hover:text-black"
+                  >
+                    Admin Dashboard
                   </Link>
                   <button
                     onClick={handleSignOut}


### PR DESCRIPTION
## Summary
- add link to admin dashboard for logged-in users on desktop header bar
- add link to admin dashboard in mobile menu

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a2d669083299c3b87c5b86d9624