### PR TITLE
Fix admin access control

### DIFF
--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -24,6 +24,11 @@ export default function AdminDashboard() {
           return;
         }
 
+        if (uRes.status === 403 || pRes.status === 403 || cRes.status === 403) {
+          router.push('/');
+          return;
+        }
+
         const uData = await uRes.json();
         const pData = await pRes.json();
         const cData = await cRes.json();

--- a/src/app/api/admin/users/route.js
+++ b/src/app/api/admin/users/route.js
@@ -8,6 +8,14 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  const currentUser = await prisma.user.findUnique({
+    where: { clerkId: userId }
+  });
+
+  if (!currentUser || currentUser.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const users = await prisma.user.findMany({
       orderBy: { createdAt: 'desc' }
@@ -23,6 +31,14 @@ export async function PATCH(request) {
   const { userId } = auth();
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const currentUser = await prisma.user.findUnique({
+    where: { clerkId: userId }
+  });
+
+  if (!currentUser || currentUser.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
   const { id, role } = await request.json();


### PR DESCRIPTION
## Summary
- enforce admin role on API routes
- handle 403 response on admin dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9cd534ec832984bcfbaf4f193e40