### PR TITLE
Fix build by avoiding remote font and marking client page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.next

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,10 +1,11 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
 import { ClerkProvider } from '@clerk/nextjs';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 
-const inter = Inter({ subsets: ['latin'] });
+// Removed the Google font import to avoid build failures when the font
+// cannot be fetched from external sources. The application will now use
+// the default sans-serif stack provided by Tailwind CSS.
 
 export const metadata = {
   title: 'Meri App',
@@ -24,7 +25,7 @@ export default function RootLayout({ children }) {
       publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
     >
       <html lang="en">
-        <body className={inter.className}>
+        <body className="font-sans">
           <div className="flex flex-col min-h-screen">
             <Navbar />
             <main className="flex-grow">

--- a/src/app/orders/page.js
+++ b/src/app/orders/page.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from 'react';
 
 export default function UserOrderPage() {


### PR DESCRIPTION
## Summary
- avoid remote font fetch in layout
- mark orders page as a client component
- ignore `.next` build artifacts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ef5c5b2108329a957b5bb0c4fafd0