### PR TITLE
Fix client page bugs

### DIFF
--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -2,11 +2,9 @@
 
 import ContactForm from '@/components/ContactForm';
 import { FaWhatsapp, FaFacebook, FaInstagram } from 'react-icons/fa';
-import { use } from 'react';
 import Link from 'next/link';
 
-export default function ContactPage({ searchParams: searchParamsPromise }) {
-  const searchParams = use(searchParamsPromise);
+export default function ContactPage({ searchParams }) {
   const { productId, subject } = searchParams || {};
   
   const socialLinks = [

--- a/src/app/messages/page.js
+++ b/src/app/messages/page.js
@@ -20,7 +20,7 @@ export default function MessagesPage() {
           throw new Error('Failed to fetch messages');
         }
         const data = await res.json();
-        setMessages(data);
+        setMessages(data.data || []);
       } catch (error) {
         console.error('Error:', error);
       } finally {

--- a/src/app/products/[id]/page.js
+++ b/src/app/products/[id]/page.js
@@ -22,7 +22,7 @@ export default function ProductPage() {
         throw new Error('Product not found');
       }
       const data = await response.json();
-      setProduct(data);
+      setProduct(data.data);
     } catch (error) {
       setError(error.message);
     } finally {

--- a/src/app/products/page.new.js
+++ b/src/app/products/page.new.js
@@ -13,7 +13,7 @@ const SimpleProductPage = () => {
       try {
         const response = await fetch('/api/products');
         const data = await response.json();
-        setProducts(data);
+        setProducts(data.data || []);
       } catch (error) {
         console.error('Error loading products:', error);
       } finally {

--- a/src/app/reset-password/page.js
+++ b/src/app/reset-password/page.js
@@ -2,10 +2,9 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { use } from 'react';
 import Link from 'next/link';
 
-export default function ResetPassword({ searchParams: searchParamsPromise }) {
+export default function ResetPassword({ searchParams }) {
   const [formData, setFormData] = useState({
     password: '',
     confirmPassword: '',
@@ -13,7 +12,6 @@ export default function ResetPassword({ searchParams: searchParamsPromise }) {
   const [status, setStatus] = useState('idle');
   const [error, setError] = useState('');
   const router = useRouter();
-  const searchParams = use(searchParamsPromise);
   const token = searchParams?.token;
 
   if (!token) {


### PR DESCRIPTION
## Summary
- handle searchParams without React `use` in contact and reset-password pages
- correctly extract `data` field from API calls on client pages

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_684efb1ccdcc8329870960bea4ee60c4