### PR TITLE
Fix admin page routing

### DIFF
--- a/src/app/admin/action.js
+++ b/src/app/admin/action.js
@@ -1,21 +1,20 @@
-"use server"
+"use server";
 
-import { auth,clerkClient } from "@clerk/nextjs/server";
-import { Roles } from "../../../types/globals";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
 
-export async function setRole(formData: FormData) {
+export async function setRole(formData) {
     const { sessionClaims } = await auth();
 
     if(sessionClaims?.publicMetadata?.role !== "admin") {
         throw new Error("Unauthorized");
     }
 
-    const client = await clerkClient();
-    const id = formData.get("id") as string;
-    const role = formData.get("role") as Roles;
+    const id = formData.get("id");
+    const role = formData.get("role");
 
     try {
-        await client.users.updateUser(id, {
+        await clerkClient.users.updateUser(id, {
             publicMetadata: { role },
         });
         revalidatePath("/admin");
@@ -24,20 +23,20 @@ export async function setRole(formData: FormData) {
      }
 }
 
-export async function removeRole(formData: FormData) {
+export async function removeRole(formData) {
   const { sessionClaims } = await auth();
 
   if (sessionClaims?.metadata?.role !== "admin") {
     throw new Error("Not Authorized");
   }
 
-  const client = await clerkClient();
-  const id = formData.get("id") as string;
+  const id = formData.get("id");
 
   try {
-    await client.users.updateUser(id, {
+    await clerkClient.users.updateUser(id, {
       publicMetadata: { role: null },
     });
+    revalidatePath("/admin");
   } catch {
     throw new Error("Failed to remove role");
   }

--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -1,9 +1,8 @@
 import { clerkClient } from "@clerk/nextjs/server";
-import { removeRole, setRole } from "./actions";
+import { removeRole, setRole } from "./action";
 
 export default async function Admin() {
   const client = await clerkClient();
-
   const users = (await client.users.getUserList()).data;
 
   return (


### PR DESCRIPTION
## Summary
- correct import of admin server actions
- update admin actions to use Clerk client properly

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f6a41fcec832987e6f92a3092e20d